### PR TITLE
Update Certus MCP server config to use streamable-http

### DIFF
--- a/librechat.yaml
+++ b/librechat.yaml
@@ -18,13 +18,16 @@ interface:
 registration:
   socialLogins: ['github', 'google', 'discord']
 
-# Certus MCP Server - Using stdio wrapper
+# Certus MCP Server - Using direct streamable-http transport
 mcpServers:
   certus:
-    command: node
-    args: ["/app/certus-mcp-stdio.js"]  # Path inside container
+    type: streamable-http
+    url: https://certus.opensource.mieweb.org/mcp
     timeout: 120000  # 2 minute timeout
     initTimeout: 60000  # 1 minute initialization timeout
+    headers:
+      User-Agent: LibreChat-MCP-Client
+      Content-Type: application/json
     serverInstructions: |
       When using Certus medical tools:
       - Use specific drug names for better results


### PR DESCRIPTION
Switched Certus MCP server from stdio wrapper to direct streamable-http transport. Updated configuration to include URL, headers, and removed command/args fields.
