### PR TITLE
revert Certus MCP server config to use stdio wrapper

### DIFF
--- a/librechat.yaml
+++ b/librechat.yaml
@@ -18,15 +18,13 @@ interface:
 registration:
   socialLogins: ['github', 'google', 'discord']
 
-# Certus MCP Server - Using streamable-http transport (explicit type required)
+# Certus MCP Server - Using stdio wrapper
 mcpServers:
   certus:
-    type: streamable-http  # REQUIRED - cannot be auto-detected
-    url: https://certus.opensource.mieweb.org/mcp
+    command: node
+    args: ["/app/certus-mcp-stdio.js"]  # Path inside container
     timeout: 120000  # 2 minute timeout
     initTimeout: 60000  # 1 minute initialization timeout
-    headers:
-      User-Agent: LibreChat-MCP-Client
     serverInstructions: |
       When using Certus medical tools:
       - Use specific drug names for better results


### PR DESCRIPTION
Switches the Certus MCP server configuration from streamable-http transport back to using a stdio wrapper with a node command and arguments. Removes the explicit type, URL, and headers, and updates the configuration to match the new execution method.